### PR TITLE
Bug/20 - package-lock.json has merge-conflicts left behind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+/.idea
 
 # testing
 /coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -6606,14 +6606,11 @@
       "requires": {
         "no-case": "2.3.2"
       }
-<<<<<<< HEAD
-=======
     },
     "parchment": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.1.tgz",
       "integrity": "sha512-+9UT5NZVBCsdRqi3vJ8n73iPEHlA+OcHzf8F+AFLw/XP6VDg737zZQ0yMfDqC6QiSSpkrNXdZ2XcCNPBgDuiSQ=="
->>>>>>> sidenav
     },
     "parse-asn1": {
       "version": "5.1.0",
@@ -8181,14 +8178,11 @@
         "object-assign": "4.1.1",
         "prop-types": "15.5.10"
       }
-<<<<<<< HEAD
-=======
     },
     "react-dom-factories": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/react-dom-factories/-/react-dom-factories-1.0.2.tgz",
       "integrity": "sha1-63cFxNs2+1AbOqOP91lhaqD/luA="
->>>>>>> sidenav
     },
     "react-error-overlay": {
       "version": "2.0.1",
@@ -8222,14 +8216,14 @@
         }
       }
     },
-<<<<<<< HEAD
     "react-input-autosize": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.1.2.tgz",
       "integrity": "sha512-uAfIE4XEfBNXqjqQvd31Eoo20UkVk0xHJpfgP8HRT8gLczaN4LEmB1e2d8CJ5ziEt4clWnsk/1+QhTN27iO/EA==",
       "requires": {
         "prop-types": "15.5.10"
-=======
+      }
+    },
     "react-quill": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/react-quill/-/react-quill-1.2.0.tgz",
@@ -8242,7 +8236,6 @@
         "prop-types": "15.5.10",
         "quill": "1.3.4",
         "react-dom-factories": "1.0.2"
->>>>>>> sidenav
       }
     },
     "react-redux": {


### PR DESCRIPTION
#20 

Removes merge-artifacts from `package-lock.json` and also adds yet-another IDE's temp-file-folder to `.gitignore` (in this case, PHPStorm / most IntelliJ based IDEs)

This fixes the problem where `npm install` failed because NPM was unable to parse `package-lock.json` due to the 'malformed' JSON (i.e. the merge-conflict artifacts)